### PR TITLE
Improve P5 instruction template description

### DIFF
--- a/P5-CodeGeneration.ipynb
+++ b/P5-CodeGeneration.ipynb
@@ -208,11 +208,11 @@
    "source": [
     "### Binary Operations:\n",
     "```python\n",
-    "('add_type', left, right, target)   # target = left + right\n",
-    "('sub_type', left, right, target)   # target = left - right\n",
-    "('mul_type', left, right, target)   # target = left * right\n",
-    "('div_type', left, right, target)   # target = left / right  (integer truncation)\n",
-    "('mod_type', left, right, target)   # target = left % rigth\n",
+    "('add_<type>', left, right, target)   # target = left + right\n",
+    "('sub_<type>', left, right, target)   # target = left - right\n",
+    "('mul_<type>', left, right, target)   # target = left * right\n",
+    "('div_<type>', left, right, target)   # target = left / right  (integer truncation)\n",
+    "('mod_<type>', left, right, target)   # target = left % rigth\n",
     "```"
    ]
   },
@@ -222,7 +222,7 @@
    "source": [
     "### Unary Operations:\n",
     "```python\n",
-    "('not_type', expr, target)          # target = !expr\n",
+    "('not_<type>', expr, target)          # target = !expr\n",
     "```"
    ]
   },
@@ -232,7 +232,7 @@
    "source": [
     "### Relational/Equality/Logical:\n",
     "```python\n",
-    "('oper_type', left, right, target)   # target = left `oper` rigth, where `oper` is:\n",
+    "('oper_<type>', left, right, target)   # target = left `oper` rigth, where `oper` is:\n",
     "                                     #          lt, le, ge, gt, eq, ne, and, or, not\n",
     "```"
    ]
@@ -255,13 +255,13 @@
    "source": [
     "### Functions & Builtins:\n",
     "```python\n",
-    "('define_type', source, args)    # Function definition. Source=function label, args=list of pairs\n",
+    "('define_<type>', source, args)    # Function definition. Source=function label, args=list of pairs\n",
     "                                 # (type, name) of formal arguments. \n",
-    "('call_type', source, target)    # Call a function. target is an optional return value\n",
-    "('return_type', target)          # Return from function. target is an optional return value\n",
-    "('param_type', source)           # source is an actual parameter\n",
-    "('read_type', source)            # Read value to source\n",
-    "('print_type', source)           # Print value of source\n",
+    "('call_<type>', source, target)    # Call a function. target is an optional return value\n",
+    "('return_<type>', target)          # Return from function. target is an optional return value\n",
+    "('param_<type>', source)           # source is an actual parameter\n",
+    "('read_<type>', source)            # Read value to source\n",
+    "('print_<type>', source)           # Print value of source\n",
     "```"
    ]
   },


### PR DESCRIPTION
# Descrição

Foi confuso entender a descrição das instruções da uCIR no modelo oferecido. Particularmente, o `type` parecia ser parte integrante da instrução.

Após ver os exemplos ficou mais claro, mas acredito que seja conveniente mudar para a forma utilizada neste PR para facilitar a compreensão dos alunos. No meu caso, mesmo depois de ter compreendido a forma correta, ainda ocorriam algumas confusões ao olhar para as o trecho do código em questão.

# Ilustração das mudanças
Antes
![image](https://github.com/mc921-1s23/notebooks/assets/65794514/5c24db6b-0aa7-4819-b8f1-c39823e63a4f)

Depois
![image](https://github.com/mc921-1s23/notebooks/assets/65794514/a813c6e9-c902-4638-b21f-83d53481dd8c)