### PR TITLE
Fix minor typo

### DIFF
--- a/P6-Dataflow.ipynb
+++ b/P6-Dataflow.ipynb
@@ -228,7 +228,7 @@
     "eliminated.\n",
     "\n",
     "Example:\n",
-    "In the example below, the value assigned to it is never used, and the dead store can be\n",
+    "In the example below, the value assigned to i is never used, and the dead store can be\n",
     "eliminated. The first assignment to global is dead, and the third assignment to global\n",
     "is unreachable; both can be eliminated.\n",
     "\n",


### PR DESCRIPTION
Fix a typo where variable `i` is referenced as `it` in P6 notebook.